### PR TITLE
Update NiceGUI version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 crisprzip>=1.1.1
 matplotlib
-nicegui
+nicegui>=2.17.0
 numpy
 pandas
 plotly


### PR DESCRIPTION
Updates the `requirements.txt` file to specify NiceGUI version 2.17.0 or higher, which is needed to support the `ui.download.content()` method used. Previous versions cause an 'AttributeError' when attempting to download. I was on 2.12 before. This method was introduced in NiceGUI 2.14.0 and stabilized in version 2.17.0.