### PR TITLE
Developing Linux executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Python
 content/__pycache__
+crisprzip_venv/
 
 # macOS
 .DS_Store

--- a/bin/build_linos.sh
+++ b/bin/build_linos.sh
@@ -1,0 +1,14 @@
+lib_path="$HOME/Documents/CRISPRzip/crisprzip-tool/crisprzip_venv/lib/python3.12/"
+
+pyinstaller crisprzip_gui.py \
+  --name CRISPRzip \
+  --windowed \
+  --onefile \
+  --add-data "$lib_path/site-packages/nicegui:nicegui/static" \
+  --add-data "$lib_path/site-packages/latex2mathml:latex2mathml" \
+  --collect-all nicegui \
+  --collect-all crisprzip \
+  --collect-all matplotlib \
+  --collect-all numpy \
+  --collect-all pandas \
+  --hidden-import uvicorn.logging

--- a/bin/build_linos.sh
+++ b/bin/build_linos.sh
@@ -11,4 +11,7 @@ pyinstaller crisprzip_gui.py \
   --collect-all matplotlib \
   --collect-all numpy \
   --collect-all pandas \
-  --hidden-import uvicorn.logging
+  --collect-all qtpy \
+  --hidden-import uvicorn.logging \
+  --hidden-import PySide6.QtWebEngineWidgets \
+  --exclude-module gi --exclude-module PyGObject --exclude-module gtk

--- a/bin/build_win.cmd
+++ b/bin/build_win.cmd
@@ -1,0 +1,14 @@
+set "VENV_PATH=%USERPROFILE%\Anaconda3\envs\cziptool_venv"
+
+pyinstaller crisprzip_gui.py ^
+    --name CRISPRzip ^
+    --onefile ^
+    --windowed ^
+    --add-data "%VENV_PATH%\Lib\site-packages\nicegui\static;nicegui/static" ^
+    --add-data "%VENV_PATH%\Lib\site-packages\latex2mathml\;latex2mathml" ^
+    --collect-all nicegui ^
+    --collect-all crisprzip ^
+    --collect-all matplotlib ^
+    --collect-all numpy ^
+    --collect-all pandas ^
+    --hidden-import uvicorn.logging

--- a/crisprzip_gui.py
+++ b/crisprzip_gui.py
@@ -1,4 +1,4 @@
-from nicegui import ui
+from nicegui import native,ui
 import content.vitro_cleavage
 import content.vitro_binding
 

--- a/crisprzip_gui.py
+++ b/crisprzip_gui.py
@@ -3,8 +3,8 @@ import content.vitro_cleavage
 import content.vitro_binding
 
 # macOS packaging support
-from multiprocessing import freeze_support
-freeze_support()
+#from multiprocessing import freeze_support
+#freeze_support()
 
 
 @ui.page('/')
@@ -59,8 +59,8 @@ def index():
 
 ui.run(
     # Uncomment the next two lines if you want to build an executable, or to run in a contained window
-    #native=True,
-    #reload=False,
+    native=True,
+    reload=False,
     title='CRISPRzip tool',
     favicon="img/CRISPRzip_logo_v0_gradient_nobg.svg"
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ pandas
 latex2mathml
 pyinstaller 
 pywebview
+PySide6
+qtpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ nicegui>=2.17.0
 numpy
 pandas
 latex2mathml
+pyinstaller 
+pywebview


### PR DESCRIPTION
Builds a nicegui executable with pyinstaller on a linux machine (UBUNTU 24.04.22 LTS)

Execution threw

```bash
[pywebview] GTK cannot be loaded
Traceback (most recent call last):
  File "webview/guilib.py", line 37, in import_gtk
  File "PyInstaller/loader/pyimod02_importers.py", line 457, in exec_module
  File "webview/platforms/gtk.py", line 20, in <module>
ModuleNotFoundError: No module named 'gi'
[pywebview] QT cannot be loaded
Traceback (most recent call last):
  File "webview/guilib.py", line 49, in import_qt
  File "PyInstaller/loader/pyimod02_importers.py", line 457, in exec_module
  File "webview/platforms/qt.py", line 23, in <module>
ModuleNotFoundError: No module named 'qtpy'
Process Process-1:
Traceback (most recent call last):
  File "multiprocessing/process.py", line 314, in _bootstrap
  File "multiprocessing/process.py", line 108, in run
  File "nicegui/native/native_mode.py", line 52, in _open_window
    webview.start(**{'storage_path': tempfile.mkdtemp(), **core.app.native.start_args})
  File "webview/__init__.py", line 176, in start
  File "webview/guilib.py", line 124, in initialize
webview.errors.WebViewException: You must have either QT or GTK with Python extensions installed in order to use pywebview.
```

As a recommendation for pywebview found:

For pywebview, QT (specifically PyQt5 or PySide6) is often recommended due to its strong cross-platform support and more robust web engine integration (QtWebEngine). While GTK also works, PyQt/PySide tend to provide a more consistent experience across different Linux distributions and potentially easier debugging/setup for the web component.

Therefore used:

`pip install PySide6`
`pip install qtpy`

`sudo apt install libqt6webenginecore6 libqt6webenginequick6 libqt6webenginewidgets6`


